### PR TITLE
Fix import functionality

### DIFF
--- a/RamsaySt.roboFontExt/info.plist
+++ b/RamsaySt.roboFontExt/info.plist
@@ -30,9 +30,9 @@
 	<key>requiresVersionMinor</key>
 	<string>0</string>
 	<key>timeStamp</key>
-	<real>1320233007.075783</real>
+	<real>1562534296.237094</real>
 	<key>version</key>
-	<string>1.5</string>
+	<string>1.5.1</string>
 	<key>com.robofontmechanic.Mechanic</key>
 	<dict>
 		<key>repository</key>

--- a/RamsaySt.roboFontExt/lib/ramsayStSettings.py
+++ b/RamsaySt.roboFontExt/lib/ramsayStSettings.py
@@ -132,7 +132,7 @@ class RamsayStSettingsWindowController(BaseWindowController):
                 items = line.split()
                 if len(items) != 3:
                     continue
-                glyphName, leftGlyphName, rightGlyphName = items
+                leftGlyphName, glyphName, rightGlyphName = items
                 data[glyphName] = leftGlyphName, rightGlyphName
 
             RamsayStData.clear()


### PR DESCRIPTION
The import functionality was broken in a way so that the main glyph and left partner glyphs were swapped. As a result, only a single entry would be imported.

This should fix #2.