### PR TITLE
make neighbors more active, change preview color through appearance

### DIFF
--- a/RamsaySt.roboFontExt/info.plist
+++ b/RamsaySt.roboFontExt/info.plist
@@ -30,8 +30,8 @@
 	<key>requiresVersionMinor</key>
 	<string>4b</string>
 	<key>timeStamp</key>
-	<real>1684939741.053118</real>
+	<real>1685122743.10727</real>
 	<key>version</key>
-	<string>2.3</string>
+	<string>2.4</string>
 </dict>
 </plist>

--- a/RamsaySt.roboFontExt/lib/ramsaySt.py
+++ b/RamsaySt.roboFontExt/lib/ramsaySt.py
@@ -10,8 +10,9 @@ class RamsaySts(Subscriber):
 
     def build(self):
         glyphEditor = self.getGlyphEditor()
-        previewFillColor = getDefault(
+        self.previewFillColor = getDefault(
             appearanceColorKey("glyphViewPreviewFillColor"))
+        self.previewKey = getDefault("glyphViewQuickPreviewKey")
         self.leftGlyph = self.rightGlyph = None
 
         container = glyphEditor.extensionContainer(RamsayStData.identifier, location="foreground")
@@ -30,11 +31,11 @@ class RamsaySts(Subscriber):
 
         previewContainer = glyphEditor.extensionContainer(RamsayStData.identifier, location="preview")
         self.previewLeftGlyphContainer = previewContainer.appendPathSublayer(
-            fillColor=previewFillColor,
+            fillColor=self.previewFillColor,
             visible=False
         )
         self.previewRightGlyphContainer = previewContainer.appendPathSublayer(
-            fillColor=previewFillColor,
+            fillColor=self.previewFillColor,
             visible=False
         )
 
@@ -80,6 +81,9 @@ class RamsaySts(Subscriber):
         self.previewRightGlyphContainer.setPosition((glyph.width, 0))
 
     def glyphEditorDidMouseDown(self, info):
+        '''
+        triple-click any neighbor glyph to jump directly to it
+        '''
         if info["deviceState"]["clickCount"] == 3:
             x, y = info["locationInGlyph"]
             glyph = info["glyph"]
@@ -91,6 +95,14 @@ class RamsaySts(Subscriber):
             if self.rightGlyph is not None:
                 if self.rightGlyph.pointInside((x - glyph.width, y)):
                     self.getGlyphEditor().setGlyph(self.rightGlyph)
+
+    def glyphEditorDidKeyDown(self, info):
+        '''
+        refresh neighbors when the preview key is hit
+        (to avoid looking at outdated neighbors)
+        '''
+        if info['deviceState']['keyDownWithoutModifiers'] == self.previewKey:
+            self.setGlyph(info["glyph"])
 
     def ramsayStSettingDidChange(self, info):
         self.leftGlyphContainer.setFillColor(RamsayStData.fillColor)

--- a/RamsaySt.roboFontExt/lib/ramsaySt.py
+++ b/RamsaySt.roboFontExt/lib/ramsaySt.py
@@ -12,7 +12,6 @@ class RamsaySts(Subscriber):
         glyphEditor = self.getGlyphEditor()
         previewFillColor = getDefault(
             appearanceColorKey("glyphViewPreviewFillColor"))
-        self.previewKey = getDefault("glyphViewQuickPreviewKey")
         self.leftGlyph = self.rightGlyph = None
 
         container = glyphEditor.extensionContainer(RamsayStData.identifier, location="foreground")
@@ -62,6 +61,8 @@ class RamsaySts(Subscriber):
                 self.rightGlyphContainer.setPosition((glyph.width, 0))
                 self.previewRightGlyphContainer.setPosition((glyph.width, 0))
 
+        self.setAdjunctObjectsToObserve([self.leftGlyph, self.rightGlyph])
+
         self.leftGlyphContainer.setPath(leftPath)
         self.rightGlyphContainer.setPath(rightPath)
         self.leftGlyphContainer.setVisible(RamsayStData.showNeighbours)
@@ -74,7 +75,6 @@ class RamsaySts(Subscriber):
 
     def glyphEditorDidSetGlyph(self, info):
         self.setGlyph(info["glyph"])
-        self.setAdjunctObjectsToObserve([self.leftGlyph, self.rightGlyph])
 
     def glyphEditorGlyphDidChangeMetrics(self, info):
         glyph = info["glyph"]
@@ -98,7 +98,8 @@ class RamsaySts(Subscriber):
                     self.getGlyphEditor().setGlyph(self.rightGlyph)
 
     def adjunctGlyphDidChange(self, info):
-        self.setGlyph(info["glyph"])
+        centerGlyph = self.getGlyphEditor().getGlyph()
+        self.setGlyph(centerGlyph)
 
     def roboFontAppearanceChanged(self, info):
         rgba = getDefault(

--- a/RamsaySt.roboFontExt/lib/ramsaySt.py
+++ b/RamsaySt.roboFontExt/lib/ramsaySt.py
@@ -74,6 +74,7 @@ class RamsaySts(Subscriber):
 
     def glyphEditorDidSetGlyph(self, info):
         self.setGlyph(info["glyph"])
+        self.setAdjunctObjectsToObserve([self.leftGlyph, self.rightGlyph])
 
     def glyphEditorGlyphDidChangeMetrics(self, info):
         glyph = info["glyph"]
@@ -96,13 +97,8 @@ class RamsaySts(Subscriber):
                 if self.rightGlyph.pointInside((x - glyph.width, y)):
                     self.getGlyphEditor().setGlyph(self.rightGlyph)
 
-    def glyphEditorDidKeyDown(self, info):
-        '''
-        refresh neighbors when the preview key is hit
-        (to avoid looking at outdated neighbors)
-        '''
-        if info['deviceState']['keyDownWithoutModifiers'] == self.previewKey:
-            self.setGlyph(info["glyph"])
+    def adjunctGlyphDidChange(self, info):
+        self.setGlyph(info["glyph"])
 
     def roboFontAppearanceChanged(self, info):
         rgba = getDefault(

--- a/RamsaySt.roboFontExt/lib/ramsaySt.py
+++ b/RamsaySt.roboFontExt/lib/ramsaySt.py
@@ -10,7 +10,7 @@ class RamsaySts(Subscriber):
 
     def build(self):
         glyphEditor = self.getGlyphEditor()
-        self.previewFillColor = getDefault(
+        previewFillColor = getDefault(
             appearanceColorKey("glyphViewPreviewFillColor"))
         self.previewKey = getDefault("glyphViewQuickPreviewKey")
         self.leftGlyph = self.rightGlyph = None
@@ -31,11 +31,11 @@ class RamsaySts(Subscriber):
 
         previewContainer = glyphEditor.extensionContainer(RamsayStData.identifier, location="preview")
         self.previewLeftGlyphContainer = previewContainer.appendPathSublayer(
-            fillColor=self.previewFillColor,
+            fillColor=previewFillColor,
             visible=False
         )
         self.previewRightGlyphContainer = previewContainer.appendPathSublayer(
-            fillColor=self.previewFillColor,
+            fillColor=previewFillColor,
             visible=False
         )
 
@@ -103,6 +103,12 @@ class RamsaySts(Subscriber):
         '''
         if info['deviceState']['keyDownWithoutModifiers'] == self.previewKey:
             self.setGlyph(info["glyph"])
+
+    def roboFontAppearanceChanged(self, info):
+        rgba = getDefault(
+            appearanceColorKey("glyphViewPreviewFillColor"))
+        self.previewLeftGlyphContainer.setFillColor(rgba)
+        self.previewRightGlyphContainer.setFillColor(rgba)
 
     def ramsayStSettingDidChange(self, info):
         self.leftGlyphContainer.setFillColor(RamsayStData.fillColor)


### PR DESCRIPTION
~~I also tried to refresh the `previewFillColor` every time the preview is hit (hence the `self`), but this was not successful. Currently, the preview color sticks to the original color even when the mode changes from light to dark. I added `self.previewFillColor = getDefault(appearanceColorKey("glyphViewPreviewFillColor"))` to the new method, but that didn’t work.~~
