### PR TITLE
Respect neighbor assignment for composite glyphs

### DIFF
--- a/info.yaml
+++ b/info.yaml
@@ -3,7 +3,7 @@ developer: TypeMyType
 developerURL: http://www.typemytype.com
 launchAtStartUp: true
 mainScript: ramsaySt.py
-version: '2.6'
+version: '2.7'
 addToMenu:
 - path: ramsayStSettings.py
   preferredName: Ramsay St. Settings

--- a/source/lib/ramsaySt.py
+++ b/source/lib/ramsaySt.py
@@ -46,8 +46,14 @@ class RamsaySts(Subscriber):
 
         if glyph is not None:
             layer = glyph.layer
-            baseName = RamsayStData.getBaseGlyph(glyph.name)
-            leftGlyphName, rightGlyphName = RamsayStData.get(baseName, ("n", "n"))
+            if glyph.name in RamsayStData:
+                # (composed) glyph + neighbors specified in RamsaySt settings
+                leftGlyphName, rightGlyphName = RamsayStData.get(glyph.name)
+            else:
+                # fall back to base glyph (e.g. a for aacute), and show
+                # neighbors for it (if assigned), or default neighbors n, n
+                baseName = RamsayStData.getBaseGlyph(glyph.name)
+                leftGlyphName, rightGlyphName = RamsayStData.get(baseName, ("n", "n"))
 
             if leftGlyphName in layer:
                 self.leftGlyph = layer[leftGlyphName]


### PR DESCRIPTION
I found out that an explicit neighbor assignment for ldot would not work – I still saw the neighbors assigned for l. The reason for this was RamsaySt always decomposing composite glyphs (via `getBaseGlyph`) – which isn’t a problem for non-composite glyphs, but will lead to a glyph list in which not all pairs work.

This update checks if the glyph name exists in the RamsaySt data first, and only then falls back to the composite’s base glyph.