### PR TITLE
draw neighbors in the “middleground”

### DIFF
--- a/info.yaml
+++ b/info.yaml
@@ -3,7 +3,7 @@ developer: TypeMyType
 developerURL: http://www.typemytype.com
 launchAtStartUp: true
 mainScript: ramsaySt.py
-version: '2.7.1'
+version: '2.7.2'
 addToMenu:
 - path: ramsayStSettings.py
   preferredName: Ramsay St. Settings

--- a/source/lib/ramsaySt.py
+++ b/source/lib/ramsaySt.py
@@ -14,7 +14,7 @@ class RamsaySts(Subscriber):
             appearanceColorKey("glyphViewPreviewFillColor"))
         self.leftGlyph = self.rightGlyph = None
 
-        container = glyphEditor.extensionContainer(RamsayStData.identifier, location="foreground")
+        container = glyphEditor.extensionContainer(RamsayStData.identifier, location="middleground")
         self.leftGlyphContainer = container.appendPathSublayer(
             fillColor=RamsayStData.fillColor,
             strokeColor=RamsayStData.strokeColor,


### PR DESCRIPTION
below outlines, above images (https://robofont.com/documentation/reference/api/mojo/mojo-events/#mojo.events.extensionContainer)

fixes #6