### PR TITLE
Add save method call in settings update

### DIFF
--- a/source/lib/ramsayStSettings.py
+++ b/source/lib/ramsayStSettings.py
@@ -173,6 +173,7 @@ class RamsayStSettingsController(ezui.WindowController):
         RamsayStData.strokeColorDark = self.w.getItem("strokeColorDark").get()
         RamsayStData.showNeighbours = self.w.getItem("showNeighborsEditMode").get()
         RamsayStData.showPreview = self.w.getItem("showNeighborsPreviewMode").get()
+        RamsayStData.save()
         postEvent(RamsayStData.changedEventName)
 
     def saveTableData(self):


### PR DESCRIPTION
Should fix the bug where settings from the upper form aren't written on change.

Tested on RoboFont 4.6 (build 2602231550)